### PR TITLE
Unify matrix/sparse network fabrication via StageMatrix trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,5 +27,4 @@ pub use sparse_matrix::{
 
 pub use network::{Evaluator, Fabricator, StatefulEvaluator, StatefulFabricator};
 
-type Matrix = Vec<Vec<f64>>;
 type Transformations = Vec<fn(f64) -> f64>;

--- a/src/matrix/feedforward/fabricator.rs
+++ b/src/matrix/feedforward/fabricator.rs
@@ -11,6 +11,16 @@ impl StageMatrix for DMatrix<f64> {
         col_indices: Vec<usize>,
         data: Vec<f64>,
     ) -> Self {
+        debug_assert_eq!(
+            row_indices.len(),
+            col_indices.len(),
+            "from_stage_data: row_indices and col_indices must have the same length"
+        );
+        debug_assert_eq!(
+            row_indices.len(),
+            data.len(),
+            "from_stage_data: row_indices and data must have the same length"
+        );
         let mut m = DMatrix::zeros(rows, cols);
         for ((&c, &r), &v) in col_indices.iter().zip(row_indices.iter()).zip(data.iter()) {
             m[(r, c)] = v;

--- a/src/matrix/feedforward/fabricator.rs
+++ b/src/matrix/feedforward/fabricator.rs
@@ -1,17 +1,21 @@
-use crate::network::{EdgeLike, Fabricator, NetworkLike, NodeLike};
-use nalgebra::{DMatrix, DVector};
-use std::collections::HashMap;
+use crate::network::{fabricate_stages, EdgeLike, Fabricator, NetworkLike, NodeLike, StageMatrix};
+use nalgebra::DMatrix;
 
 pub struct MatrixFeedforwardFabricator;
 
-impl MatrixFeedforwardFabricator {
-    fn get_matrix(dynamic_matrix: Vec<Vec<f64>>) -> DMatrix<f64> {
-        let columns = dynamic_matrix
-            .into_iter()
-            .map(DVector::from_vec)
-            .collect::<Vec<_>>();
-
-        DMatrix::from_columns(&columns)
+impl StageMatrix for DMatrix<f64> {
+    fn from_stage_data(
+        rows: usize,
+        cols: usize,
+        row_indices: Vec<usize>,
+        col_indices: Vec<usize>,
+        data: Vec<f64>,
+    ) -> Self {
+        let mut m = DMatrix::zeros(rows, cols);
+        for ((&c, &r), &v) in col_indices.iter().zip(row_indices.iter()).zip(data.iter()) {
+            m[(r, c)] = v;
+        }
+        m
     }
 }
 
@@ -23,198 +27,10 @@ where
     type Output = super::evaluator::MatrixFeedforwardEvaluator;
 
     fn fabricate(net: &impl NetworkLike<N, E>) -> Result<Self::Output, &'static str> {
-        // build dependency graph by collecting incoming edges per node
-        let mut dependency_graph: HashMap<usize, Vec<&E>> = HashMap::new();
-
-        for edge in net.edges() {
-            dependency_graph
-                .entry(edge.end())
-                .and_modify(|dependencies| dependencies.push(edge))
-                .or_insert_with(|| vec![edge]);
-        }
-
-        if dependency_graph.is_empty() {
-            return Err("no edges present, net invalid");
-        }
-
-        // keep track of dependencies present
-        let mut dependency_count = dependency_graph.len();
-
-        // println!("initial dependency_graph {:#?}", dependency_graph);
-
-        // contains list of matrices (stages) that form the computable net
-        let mut compute_stages: Vec<crate::Matrix> = Vec::new();
-        // contains activation functions corresponding to each stage
-        let mut stage_transformations: Vec<crate::Transformations> = Vec::new();
-        // set available nodes a.k.a net input
-        let mut available_nodes = net.inputs();
-        // sort via Ord implementation of provided nodes to guarantee each input will be processed by the same node every time
-        available_nodes.sort_unstable();
-        // reduce nodes to ids
-        let mut available_nodes: Vec<usize> = available_nodes.iter().map(|n| n.id()).collect();
-
-        // println!("available_nodes {:?}", available_nodes);
-
-        // set wanted nodes a.k.a net output
-        let mut wanted_nodes = net.outputs();
-        // sort via Ord implementation of provided nodes to guarantee each output will appear in the same order every time
-        wanted_nodes.sort_unstable();
-        // reduce nodes to ids
-        let wanted_nodes: Vec<usize> = wanted_nodes.iter().map(|n| n.id()).collect();
-
-        // println!("wanted_nodes {:?}", wanted_nodes);
-
-        // gather compute stages by finding computable nodes and required carries until all dependencies are resolved
-        while !dependency_graph.is_empty() {
-            // setup new compute stage
-            let mut stage_matrix: crate::Matrix = Vec::new();
-            // setup new transformations
-            let mut transformations: crate::Transformations = Vec::new();
-            // list of nodes becoming available by compute stage
-            let mut next_available_nodes: Vec<usize> = Vec::new();
-
-            for (&dependent_node, dependencies) in dependency_graph.iter() {
-                // marker if all dependencies are available
-                let mut computable = true;
-                // eventual compute vector
-                let mut compute_or_carry = vec![f64::NAN; available_nodes.len()];
-                // check every dependency
-                for &dependency in dependencies {
-                    let mut found = false;
-                    for (index, &id) in available_nodes.iter().enumerate() {
-                        if dependency.start() == id {
-                            // add weight to compute vector at position of input
-                            compute_or_carry[index] = dependency.weight();
-                            found = true;
-                        }
-                    }
-                    // if any dependency is not found the node is not computable yet
-                    if !found {
-                        computable = false;
-                    }
-                }
-                if computable {
-                    // replace NAN with 0.0
-                    for n in &mut compute_or_carry {
-                        if n.is_nan() {
-                            *n = 0.0
-                        }
-                    }
-                    // add vec to compute stage
-                    stage_matrix.push(compute_or_carry);
-                    // add activation function to stage transformations
-                    transformations.push(
-                        net.nodes()
-                            .iter()
-                            .find(|&node| node.id() == dependent_node)
-                            .unwrap()
-                            .activation(),
-                    );
-                    // mark node as available in next iteration
-                    next_available_nodes.push(dependent_node);
-                } else {
-                    // figure out carries
-                    for (index, &weight) in compute_or_carry.iter().enumerate() {
-                        // if there is some partial dependency that is not carried yet
-                        if !next_available_nodes.contains(&available_nodes[index])
-                            && !weight.is_nan()
-                        {
-                            let mut carry = vec![0.0; available_nodes.len()];
-                            carry[index] = 1.0;
-                            // add carry vector
-                            stage_matrix.push(carry);
-                            // add identity function for carried vector
-                            transformations.push(|val| val);
-                            // add node as available
-                            next_available_nodes.push(available_nodes[index]);
-                        }
-                    }
-                }
-            }
-
-            // keep any wanted notes if available (output)
-            for wanted_node in wanted_nodes.iter() {
-                for (index, available_node) in available_nodes.iter().enumerate() {
-                    if available_node == wanted_node {
-                        // carry only if not carried already
-                        if !next_available_nodes.contains(available_node) {
-                            let mut carry = vec![0.0; available_nodes.len()];
-                            carry[index] = 1.0;
-                            // add carry vector
-                            stage_matrix.push(carry);
-                            // add identity function for carried vector
-                            transformations.push(|val| val);
-                            // add node as available
-                            next_available_nodes.push(*available_node);
-                        }
-                    }
-                }
-            }
-
-            // remove resolved dependencies from dependency graph
-            for node in next_available_nodes.iter() {
-                dependency_graph.remove(node);
-            }
-
-            // if no dependency was removed no progess was made
-            if dependency_graph.len() == dependency_count {
-                return Err("can't resolve dependencies, net invalid");
-            } else {
-                dependency_count = dependency_graph.len();
-            }
-
-            // println!("next_available_nodes {:?}", next_available_nodes);
-
-            // reorder last stage according to net output order (invalidates next_available_nodes order which wont be used after this point)
-            if dependency_graph.is_empty() {
-                // println!("stage_matrix {:?}", stage_matrix);
-
-                let mut reordered_matrix = stage_matrix.clone();
-                let mut reordered_transformations = transformations.clone();
-
-                let mut matched_wanted_count = 0;
-
-                for ((available_node, column), transformation) in next_available_nodes
-                    .iter()
-                    .zip(stage_matrix.into_iter())
-                    .zip(transformations.into_iter())
-                {
-                    for (index, wanted_node) in wanted_nodes.iter().enumerate() {
-                        if available_node == wanted_node {
-                            reordered_matrix[index] = column;
-                            reordered_transformations[index] = transformation;
-                            matched_wanted_count += 1;
-                            break;
-                        }
-                    }
-                }
-
-                if matched_wanted_count < wanted_nodes.len() {
-                    return Err(
-                        "dependencies resolved but not all outputs computable, net invalid",
-                    );
-                }
-
-                // println!("reordered_matrix {:?}", reordered_matrix);
-
-                stage_matrix = reordered_matrix;
-                transformations = reordered_transformations;
-            }
-
-            // add resolved dependencies and transformations to compute stages
-            compute_stages.push(stage_matrix);
-            stage_transformations.push(transformations);
-
-            // set available nodes for next iteration
-            available_nodes = next_available_nodes;
-        }
-
+        let (stages, transformations) = fabricate_stages::<N, E, DMatrix<f64>>(net)?;
         Ok(super::evaluator::MatrixFeedforwardEvaluator {
-            stages: compute_stages
-                .into_iter()
-                .map(MatrixFeedforwardFabricator::get_matrix)
-                .collect(),
-            transformations: stage_transformations,
+            stages,
+            transformations,
         })
     }
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -4,6 +4,8 @@ pub use self::io::NetworkIO;
 
 mod io;
 
+use std::collections::HashMap;
+
 /// Declares a structure to have [`NodeLike`] properties.
 ///
 /// [`NodeLike`] provides the plumbing to accept user-defined structures and use them as nodes in this crates context.
@@ -80,6 +82,190 @@ pub trait StatefulFabricator<N: NodeLike, E: EdgeLike> {
     type Output: StatefulEvaluator;
 
     fn fabricate(net: &impl Recurrent<N, E>) -> Result<Self::Output, &'static str>;
+}
+
+/// Abstracts over how a computation stage matrix is built from triplet (COO) data.
+///
+/// Implementing this trait allows a matrix type to be used as the backend for [`fabricate_stages`].
+pub trait StageMatrix: Sized {
+    fn from_stage_data(
+        rows: usize,
+        cols: usize,
+        row_indices: Vec<usize>,
+        col_indices: Vec<usize>,
+        data: Vec<f64>,
+    ) -> Self;
+}
+
+/// Core fabrication logic shared by all matrix-backed fabricators.
+///
+/// Resolves the computation stages for a [`NetworkLike`] structure using topological dependency
+/// resolution, carry propagation, and output reordering. The resulting stage matrices are built
+/// via [`StageMatrix::from_stage_data`], allowing both dense and sparse backends to reuse this
+/// single implementation.
+pub fn fabricate_stages<N, E, M>(
+    net: &impl NetworkLike<N, E>,
+) -> Result<(Vec<M>, Vec<crate::Transformations>), &'static str>
+where
+    N: NodeLike,
+    E: EdgeLike,
+    M: StageMatrix,
+{
+    let mut dependency_graph: HashMap<usize, Vec<&E>> = HashMap::new();
+    for edge in net.edges() {
+        dependency_graph
+            .entry(edge.end())
+            .and_modify(|deps| deps.push(edge))
+            .or_insert_with(|| vec![edge]);
+    }
+    if dependency_graph.is_empty() {
+        return Err("no edges present, net invalid");
+    }
+
+    let mut dependency_count = dependency_graph.len();
+    let mut compute_stages: Vec<(usize, usize, Vec<usize>, Vec<usize>, Vec<f64>)> = Vec::new();
+    let mut stage_transformations: Vec<crate::Transformations> = Vec::new();
+
+    let mut available_nodes = net.inputs();
+    available_nodes.sort_unstable();
+    let mut available_nodes: Vec<usize> = available_nodes.iter().map(|n| n.id()).collect();
+
+    let mut wanted_nodes = net.outputs();
+    wanted_nodes.sort_unstable();
+    let wanted_nodes: Vec<usize> = wanted_nodes.iter().map(|n| n.id()).collect();
+
+    while !dependency_graph.is_empty() {
+        let mut transformations: crate::Transformations = Vec::new();
+        let mut next_available_nodes: Vec<usize> = Vec::new();
+        let mut column_index = 0usize;
+        let mut stage_col_indices: Vec<usize> = Vec::new();
+        let mut stage_row_indices: Vec<usize> = Vec::new();
+        let mut stage_data: Vec<f64> = Vec::new();
+
+        for (&dependent_node, dependencies) in dependency_graph.iter() {
+            let mut node_col_indices = Vec::new();
+            let mut node_row_indices = Vec::new();
+            let mut node_data = Vec::new();
+            let mut computable = true;
+
+            for &dependency in dependencies {
+                let mut found = false;
+                for (row_index, &id) in available_nodes.iter().enumerate() {
+                    if dependency.start() == id {
+                        node_col_indices.push(column_index);
+                        node_row_indices.push(row_index);
+                        node_data.push(dependency.weight());
+                        found = true;
+                    }
+                }
+                if !found {
+                    computable = false;
+                }
+            }
+
+            if computable {
+                stage_col_indices.extend(node_col_indices);
+                stage_row_indices.extend(node_row_indices);
+                stage_data.extend(node_data);
+                transformations.push(
+                    net.nodes()
+                        .iter()
+                        .find(|&node| node.id() == dependent_node)
+                        .unwrap()
+                        .activation(),
+                );
+                column_index += 1;
+                next_available_nodes.push(dependent_node);
+            } else {
+                // carry partial dependencies forward
+                for row_index in node_row_indices {
+                    if !next_available_nodes.contains(&available_nodes[row_index]) {
+                        stage_row_indices.push(row_index);
+                        stage_col_indices.push(column_index);
+                        stage_data.push(1.0);
+                        column_index += 1;
+                        transformations.push(|val| val);
+                        next_available_nodes.push(available_nodes[row_index]);
+                    }
+                }
+            }
+        }
+
+        // carry wanted output nodes if already available
+        for wanted_node in wanted_nodes.iter() {
+            for (row_index, available_node) in available_nodes.iter().enumerate() {
+                if available_node == wanted_node && !next_available_nodes.contains(available_node) {
+                    stage_col_indices.push(column_index);
+                    stage_row_indices.push(row_index);
+                    stage_data.push(1.0);
+                    column_index += 1;
+                    transformations.push(|val| val);
+                    next_available_nodes.push(*available_node);
+                }
+            }
+        }
+
+        for node in next_available_nodes.iter() {
+            dependency_graph.remove(node);
+        }
+
+        if dependency_graph.len() == dependency_count {
+            return Err("can't resolve dependencies, net invalid");
+        } else {
+            dependency_count = dependency_graph.len();
+        }
+
+        // reorder last stage to match wanted output order
+        if dependency_graph.is_empty() {
+            let mut reordered_col_indices = vec![usize::MAX; stage_col_indices.len()];
+            let mut reordered_transformations = transformations.clone();
+            let mut matched_wanted_count = 0;
+
+            for (old_col, available_node) in next_available_nodes.iter().enumerate() {
+                for (new_col, wanted_node) in wanted_nodes.iter().enumerate() {
+                    if available_node == wanted_node {
+                        for (reordered, &old) in
+                            reordered_col_indices.iter_mut().zip(stage_col_indices.iter())
+                        {
+                            if old == old_col {
+                                *reordered = new_col;
+                            }
+                        }
+                        reordered_transformations[new_col] = transformations[old_col];
+                        matched_wanted_count += 1;
+                        break;
+                    }
+                }
+            }
+
+            if matched_wanted_count < wanted_nodes.len() {
+                return Err(
+                    "dependencies resolved but not all outputs computable, net invalid",
+                );
+            }
+
+            stage_col_indices = reordered_col_indices;
+            transformations = reordered_transformations;
+        }
+
+        compute_stages.push((
+            available_nodes.len(),
+            column_index,
+            stage_row_indices,
+            stage_col_indices,
+            stage_data,
+        ));
+        stage_transformations.push(transformations);
+        available_nodes = next_available_nodes;
+    }
+
+    Ok((
+        compute_stages
+            .into_iter()
+            .map(|(rows, cols, ri, ci, data)| M::from_stage_data(rows, cols, ri, ci, data))
+            .collect(),
+        stage_transformations,
+    ))
 }
 
 /// Contains an example of a [`Recurrent`] [`NetworkLike`] structure.

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -167,13 +167,13 @@ where
                 stage_col_indices.extend(node_col_indices);
                 stage_row_indices.extend(node_row_indices);
                 stage_data.extend(node_data);
-                transformations.push(
-                    net.nodes()
-                        .iter()
-                        .find(|&node| node.id() == dependent_node)
-                        .unwrap()
-                        .activation(),
-                );
+                let activation = net
+                    .nodes()
+                    .iter()
+                    .find(|&node| node.id() == dependent_node)
+                    .map(|node| node.activation())
+                    .ok_or("Invalid network: dependent node not found in nodes list")?;
+                transformations.push(activation);
                 column_index += 1;
                 next_available_nodes.push(dependent_node);
             } else {

--- a/src/sparse_matrix/feedforward/fabricator.rs
+++ b/src/sparse_matrix/feedforward/fabricator.rs
@@ -1,17 +1,18 @@
-use crate::network::{EdgeLike, Fabricator, NetworkLike, NodeLike};
+use crate::network::{fabricate_stages, EdgeLike, Fabricator, NetworkLike, NodeLike, StageMatrix};
 use nalgebra_sparse::{CooMatrix, CscMatrix};
-use std::collections::HashMap;
 
 pub struct SparseMatrixFeedforwardFabricator;
 
-impl SparseMatrixFeedforwardFabricator {
-    fn get_sparse(
-        (col_inds, row_inds, data, rows): (Vec<usize>, Vec<usize>, Vec<f64>, usize),
-    ) -> CscMatrix<f64> {
-        let colums = col_inds.iter().max().unwrap() + 1;
-
+impl StageMatrix for CscMatrix<f64> {
+    fn from_stage_data(
+        rows: usize,
+        cols: usize,
+        row_indices: Vec<usize>,
+        col_indices: Vec<usize>,
+        data: Vec<f64>,
+    ) -> Self {
         CscMatrix::from(
-            &CooMatrix::try_from_triplets(rows, colums, row_inds, col_inds, data).unwrap(),
+            &CooMatrix::try_from_triplets(rows, cols, row_indices, col_indices, data).unwrap(),
         )
     }
 }
@@ -24,213 +25,10 @@ where
     type Output = super::evaluator::SparseMatrixFeedforwardEvaluator;
 
     fn fabricate(net: &impl NetworkLike<N, E>) -> Result<Self::Output, &'static str> {
-        // build dependency graph by collecting incoming edges per node
-        let mut dependency_graph: HashMap<usize, Vec<&E>> = HashMap::new();
-
-        for edge in net.edges() {
-            dependency_graph
-                .entry(edge.end())
-                .and_modify(|dependencies| dependencies.push(edge))
-                .or_insert_with(|| vec![edge]);
-        }
-
-        if dependency_graph.is_empty() {
-            return Err("no edges present, net invalid");
-        }
-
-        // keep track of dependencies present
-        let mut dependency_count = dependency_graph.len();
-
-        // println!("initial dependency_graph {:#?}", dependency_graph);
-
-        // contains list of matrices (stages) that form the computable net
-        let mut compute_stages: Vec<(Vec<usize>, Vec<usize>, Vec<f64>, usize)> = Vec::new();
-        // contains activation functions corresponding to each stage
-        let mut stage_transformations: Vec<crate::Transformations> = Vec::new();
-        // set available nodes a.k.a net input
-        let mut available_nodes = net.inputs();
-        // sort via Ord implementation of provided nodes to guarantee each input will be processed by the same node every time
-        available_nodes.sort_unstable();
-        // reduce nodes to ids
-        let mut available_nodes: Vec<usize> = available_nodes.iter().map(|n| n.id()).collect();
-
-        // println!("available_nodes {:?}", available_nodes);
-
-        // set wanted nodes a.k.a net output
-        let mut wanted_nodes = net.outputs();
-        // sort via Ord implementation of provided nodes to guarantee each output will appear in the same order every time
-        wanted_nodes.sort_unstable();
-        // reduce nodes to ids
-        let wanted_nodes: Vec<usize> = wanted_nodes.iter().map(|n| n.id()).collect();
-
-        // println!("wanted_nodes {:?}", wanted_nodes);
-
-        // gather compute stages by finding computable nodes and required carries until all dependencies are resolved
-        while !dependency_graph.is_empty() {
-            // setup new transformations
-            let mut transformations: crate::Transformations = Vec::new();
-            // list of nodes becoming available by compute stage
-            let mut next_available_nodes: Vec<usize> = Vec::new();
-
-            let mut column_index = 0;
-            let mut stage_column_indices: Vec<usize> = Vec::new();
-            let mut stage_row_indices = Vec::new();
-            let mut stage_data = Vec::new();
-
-            for (&dependent_node, dependencies) in dependency_graph.iter() {
-                let mut node_column_indices = Vec::new();
-                let mut node_row_indices = Vec::new();
-                let mut node_data = Vec::new();
-                // marker if all dependencies are available
-                let mut computable = true;
-                // check every dependency
-                for &dependency in dependencies {
-                    let mut found = false;
-                    for (row_index, &id) in available_nodes.iter().enumerate() {
-                        // index here is row index
-                        if dependency.start() == id {
-                            node_column_indices.push(column_index);
-                            node_row_indices.push(row_index);
-                            node_data.push(dependency.weight());
-                            found = true;
-                        }
-                    }
-                    // if any dependency is not found the node is not computable yet
-                    if !found {
-                        computable = false;
-                    }
-                }
-                if computable {
-                    stage_column_indices = [stage_column_indices, node_column_indices].concat();
-                    stage_row_indices = [stage_row_indices, node_row_indices].concat();
-                    stage_data = [stage_data, node_data].concat();
-                    // add activation function to stage transformations
-                    transformations.push(
-                        net.nodes()
-                            .iter()
-                            .find(|&node| node.id() == dependent_node)
-                            .unwrap()
-                            .activation(),
-                    );
-                    column_index += 1;
-                    // mark node as available in next iteration
-                    next_available_nodes.push(dependent_node);
-                } else {
-                    let mut carry_column_indices = Vec::new();
-                    let mut carry_row_indices = Vec::new();
-                    let mut carry_data = Vec::new();
-                    for row_index in node_row_indices {
-                        if !next_available_nodes.contains(&available_nodes[row_index]) {
-                            carry_row_indices.push(row_index);
-                            carry_column_indices.push(column_index);
-                            column_index += 1;
-                            carry_data.push(1.0);
-                            transformations.push(|val| val);
-                            next_available_nodes.push(available_nodes[row_index]);
-                        }
-                    }
-                    stage_column_indices = [stage_column_indices, carry_column_indices].concat();
-                    stage_row_indices = [stage_row_indices, carry_row_indices].concat();
-                    stage_data = [stage_data, carry_data].concat();
-                }
-            }
-
-            // keep any wanted notes if available (output)
-            for wanted_node in wanted_nodes.iter() {
-                for (row_index, available_node) in available_nodes.iter().enumerate() {
-                    if available_node == wanted_node {
-                        // carry only if not carried already
-                        if !next_available_nodes.contains(available_node) {
-                            stage_column_indices.push(column_index);
-                            column_index += 1;
-                            stage_row_indices.push(row_index);
-                            stage_data.push(1.0);
-
-                            // add identity function for carried vector
-                            transformations.push(|val| val);
-                            // add node as available
-                            next_available_nodes.push(*available_node);
-                        }
-                    }
-                }
-            }
-
-            // remove resolved dependencies from dependency graph
-            for node in next_available_nodes.iter() {
-                dependency_graph.remove(node);
-            }
-
-            // if no dependency was removed no progess was made
-            if dependency_graph.len() == dependency_count {
-                return Err("can't resolve dependencies, net invalid");
-            } else {
-                dependency_count = dependency_graph.len();
-            }
-
-            // println!("next_available_nodes {:?}", next_available_nodes);
-
-            // reorder last stage according to net output order (invalidates next_available_nodes order which wont be used after this point)
-            if dependency_graph.is_empty() {
-                // println!("stage_matrix {:?}", stage_matrix);
-
-                // let mut reordered_matrix = stage_matrix.clone();
-                let mut reordered_stage_column_indices =
-                    vec![usize::MAX; stage_column_indices.len()];
-                let mut reordered_transformations = transformations.clone();
-
-                let mut matched_wanted_count = 0;
-
-                for (old_column_index, available_node) in next_available_nodes.iter().enumerate() {
-                    for (new_column_index, wanted_node) in wanted_nodes.iter().enumerate() {
-                        if available_node == wanted_node {
-                            for (reordered_index, &old_index) in reordered_stage_column_indices
-                                .iter_mut()
-                                .zip(stage_column_indices.iter())
-                            {
-                                if old_index == old_column_index {
-                                    *reordered_index = new_column_index;
-                                }
-                            }
-
-                            reordered_transformations[new_column_index] =
-                                transformations[old_column_index];
-                            matched_wanted_count += 1;
-                            break;
-                        }
-                    }
-                }
-
-                if matched_wanted_count < wanted_nodes.len() {
-                    return Err(
-                        "dependencies resolved but not all outputs computable, net invalid",
-                    );
-                }
-
-                // println!("reordered_matrix {:?}", reordered_matrix);
-
-                stage_column_indices = reordered_stage_column_indices;
-                transformations = reordered_transformations;
-            }
-
-            // add resolved dependencies and transformations to compute stages
-            compute_stages.push((
-                stage_column_indices,
-                stage_row_indices,
-                stage_data,
-                available_nodes.len(),
-            ));
-            stage_transformations.push(transformations);
-
-            // set available nodes for next iteration
-            available_nodes = next_available_nodes;
-        }
-
+        let (stages, transformations) = fabricate_stages::<N, E, CscMatrix<f64>>(net)?;
         Ok(super::evaluator::SparseMatrixFeedforwardEvaluator {
-            stages: compute_stages
-                .into_iter()
-                .map(SparseMatrixFeedforwardFabricator::get_sparse)
-                .collect(),
-            transformations: stage_transformations,
+            stages,
+            transformations,
         })
     }
 }


### PR DESCRIPTION
Extract the shared feedforward fabrication logic (dependency resolution, carry propagation, output reordering) into a single generic `fabricate_stages<N, E, M: StageMatrix>` function in `network::mod`.

Each backend implements `StageMatrix::from_stage_data` to convert the common triplet representation into its native matrix type (`DMatrix<f64>` or `CscMatrix<f64>`). Both fabricators become thin wrappers that call `fabricate_stages` and wrap the result, eliminating ~200 lines of duplicated logic.

Also removes the now-unused `type Matrix = Vec<Vec<f64>>` alias.

https://claude.ai/code/session_016CqGXhW6EbnwK1nkkcM8A8